### PR TITLE
Add support for compression on generated grpc client/server.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +112,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +137,16 @@ name = "fixedbitset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -341,6 +366,15 @@ name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -705,6 +739,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bytes",
+ "flate2",
  "futures-core",
  "futures-util",
  "h2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,8 +86,8 @@ otel-trace = [
 
 [dependencies]
 prost = { version = "0.9" }
-tonic = { version = "0.6.2" }
+tonic = { version = "0.6.2", features = ["compression"] }
 async-channel = "1"
 
 [build-dependencies]
-tonic-build = { version = "0.6.2" }
+tonic-build = { version = "0.6.2", features = ["compression"] }


### PR DESCRIPTION
### Description:

Adding this feature will generate the `send_gzip` and `accept_gzip` functions on the [client](https://docs.rs/tonic/0.6.2/tonic/client/struct.Grpc.html#method.send_gzip) and [server](https://docs.rs/tonic/0.6.2/tonic/server/struct.Grpc.html#method.send_gzip) structs. These two methods will be used to configure the **Otel** connectors in **Tremor**. `Tonic`  only supports the `Gzip` compression algorithm, so this is all we can use.

### Related Issues: 
* https://github.com/tremor-rs/tremor-runtime/issues/1688

### Testing: 
The crate builds successfully. The said methods were generated with the `grpc` client and server.
